### PR TITLE
Use invisible rectangle to center golf_pin.svg

### DIFF
--- a/style/golf.mss
+++ b/style/golf.mss
@@ -50,9 +50,9 @@
 #amenity-points[zoom >= 16] {
   [feature = 'golf_hole'],
   [feature = 'golf_pin'] {
-    marker-file: url('symbols/golf_pin.svg');
+    marker-file: url('symbols/leisure/golf_pin.svg');
     marker-fill: @address-color;
-    marker-geometry-transform: translate(2, -5);
+    marker-clip: false;
   }
 }
 

--- a/symbols/golf_pin.svg
+++ b/symbols/golf_pin.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1"
-    id="golf_pin"
-    xmlns:svg="http://www.w3.org/2000/svg"
-    xmlns="http://www.w3.org/2000/svg"
-    width="9"
-    height="13">
-   <path d="M 4 1 L 4 10.773438 A 2.107161 0.75 0 0 0 2.3925781 11.5 A 2.107161 0.75 0 0 0 4.5 12.25 A 2.107161 0.75 0 0 0 6.6074219 11.5 A 2.107161 0.75 0 0 0 5 10.773438 L 5 4 L 9 2.5566406 L 5 1 L 4 1 z"/>
-</svg>

--- a/symbols/leisure/golf_pin.svg
+++ b/symbols/leisure/golf_pin.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="9" height="23" version="1.1" viewBox="0 0 9 23">
+  <rect id="mapnik_workaround" width="9" height="23" fill="none"/>
+  <path d="m4,1 v9.77344 a2.10716,0.75 0 1 0 1,0 v-6.77344 l4,-1.5 -4,-1.5 z"/>
+</svg>


### PR DESCRIPTION
This is an easier trick to align the hole in `golf_pin.svg` with the points on the map than using `marker-transform` or `marker-geometry-transform`. I also simplified the svg a bit, and moved the file to `leisure`, where the other golf-related symbols are. No visual changes.